### PR TITLE
fix: simplify event tracking and update video event

### DIFF
--- a/src/js/modules/mixpanelEvents.js
+++ b/src/js/modules/mixpanelEvents.js
@@ -10,6 +10,8 @@ export const mixpanelEvents = {
       upvote: 'voting__button--up'
     };
 
+    this.MONITOR_INTERVAL = 300;
+
     this.cacheDOM();
   },
 
@@ -19,6 +21,7 @@ export const mixpanelEvents = {
     this.searchEventTrigger = document.querySelector(`.${this.CLASS_NAMES.search}`);
     this.scrollEventTrigger = document.querySelector(`.${this.CLASS_NAMES.scroll}`);
 
+    this.articleTitle = document.querySelector('.article__title');
     this.articleIframe = document.querySelector('.article__content iframe');
     this.articleFeedbackButtons = document.querySelectorAll('.voting__options button');
 
@@ -70,9 +73,10 @@ export const mixpanelEvents = {
 
   pageViewEvent() {
     const eventName = this.pageviewEventTrigger.dataset['event'] || null;
+    const eventParams = this.pageviewEventTrigger.dataset['params'] || {};
 
     if (eventName) {
-      mixpanel.track(eventName);
+      mixpanel.track(eventName, JSON.parse(eventParams));
     }
   },
 
@@ -87,12 +91,11 @@ export const mixpanelEvents = {
 
   feedbackEvent(button) {
     const vote = button.classList.contains(this.CLASS_NAMES.upvote) ? 'up' : 'down';
-    const eventParams = {
-      title: document.querySelector('.article__title ').innerText,
-      answer: vote
-    };
 
-    mixpanel.track('w_all_faq_article_btn2_clk_feedback', eventParams);
+    mixpanel.track('w_all_faq_article_btn2_clk_feedback', {
+      articleTitle: this.articleTitle.innerText,
+      answer: vote
+    });
   },
 
   searchEvent() {
@@ -109,18 +112,17 @@ export const mixpanelEvents = {
   },
 
   videoEvent() {
-    document.body.addEventListener('click', () => {
+    const monitor = setInterval(() => {
       const { activeElement } = document;
 
-      if (activeElement.tagName.toLowerCase() === 'iframe') {
-        const eventName = 'w_all_faq_article_video_view';
-        const eventParams = { title: document.querySelector('.article__title ').innerText };
+      if (activeElement && activeElement.tagName.toLowerCase() === 'iframe') {
+        mixpanel.track('w_all_faq_article_video_view', {
+          articleTitle: this.articleTitle.innerText
+        });
 
-        if (eventName && eventParams) {
-          mixpanel.track(eventName, eventParams);
-        }
+        clearInterval(monitor);
       }
-    });
+    }, this.MONITOR_INTERVAL);
   },
 
   attachScrollEvent() {

--- a/src/templates/article_page.hbs
+++ b/src/templates/article_page.hbs
@@ -1,6 +1,7 @@
 <div
   class="page-container article-page mxp-pgv-event"
   data-event="w_all_faq_article_pg_view"
+  data-params="{ articleTitle: {{ article.title }} }"
 >
   <section class="section section--head">
     <div class="section__container">
@@ -90,7 +91,7 @@
                     class="button button--primary voting__button voting__button--msg toggle-chat mxp-click-event"
                     title="Iniciar chat"
                     data-event="w_all_faq_article_btn1_clk_chat"
-                    data-params="{ title: {{ article.title }} }"
+                    data-params="{ articleTitle: {{ article.title }} }"
                   >
                     {{ settings.article_voting_contact_cta }}
                   </button>

--- a/src/templates/category_page.hbs
+++ b/src/templates/category_page.hbs
@@ -2,6 +2,7 @@
   id="main-content"
   class="page-container category-page mxp-pgv-event mxp-sll-event"
   data-event="w_all_faq_home_pg_view"
+  data-params="{ category: {{ category.name }} }"
   data-scroll="footer"
 >
   <section class="section section--head">
@@ -67,7 +68,7 @@
                       href="{{ url }}"
                       class="article mxp-click-event"
                       data-event="w_all_faq_category_list_clk"
-                      data-params="{ title: {{ title }} }"
+                      data-params="{ articleTitle: {{ title }} }"
                     >
                       <span class="article__title">{{ title }}</span>
                       <span class="article__excerpt">{{excerpt body characters=200}}</span>


### PR DESCRIPTION
## Description
- Simplify event tracking code, removing middleman variables
- Replace video event tracking, from click on body to setInterval
- Add missing params on page view events and update params naming

## Screenshots
<!-- (optional) when applicable, please include some screenshots or gifs that illustrate the changes -->

## Checklist
- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [x] :nail_care: SASS files are compiled
- [x] :arrow_left: changes are compatible with RTL direction
- [x] :wheelchair: changes are accessible
- [x] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [x] :iphone: changes are responsive and tested in mobile
